### PR TITLE
Use attachWith instead of attachDynWith

### DIFF
--- a/src/Reflex/Dom/Widget/Input.hs
+++ b/src/Reflex/Dom/Widget/Input.hs
@@ -185,7 +185,7 @@ dropdown k0 options (DropdownConfig setK attrs) = do
         guard $ Map.member k opts
         return k
   dValue <- combineDyn readKey options =<< holdDyn (Just k0) (leftmost [eChange, fmap Just setK])
-  return $ Dropdown dValue (attachDynWith readKey options eChange)
+  return $ Dropdown dValue (attachWith readKey (current options) eChange)
 
 liftM concat $ mapM makeLenses
   [ ''TextAreaConfig


### PR DESCRIPTION
The `attachDynWith` introduces infinite looping for cyclic data flows, as explained in the documentation of `tagDyn`.