### PR TITLE
Fix `source-repository` entry in reflex-dom

### DIFF
--- a/reflex-dom.cabal
+++ b/reflex-dom.cabal
@@ -74,4 +74,4 @@ library
 
 source-repository head
   type: git
-  location: https://github.com/ryantrinkle/reflex
+  location: https://github.com/ryantrinkle/reflex-dom


### PR DESCRIPTION
...which was referring to `reflex`, not `reflex-dom`.