### PR TITLE
Prevent buttons from submitting form contents

### DIFF
--- a/src/Reflex/Dom/Widget/Basic.hs
+++ b/src/Reflex/Dom/Widget/Basic.hs
@@ -796,7 +796,7 @@ link s = linkClass s ""
 
 button :: MonadWidget t m => String -> m (Event t ())
 button s = do
-  (e, _) <- el' "button" $ text s
+  (e, _) <- elAttr' "button" (Map.singleton "type" "button") $ text s
   return $ domEvent Click e
 
 newtype Workflow t m a = Workflow { unWorkflow :: m (a, Event t (Workflow t m a)) }


### PR DESCRIPTION
It is unlikely one would like a button press to submit the content of a form. This patch changes the default type of the button widget from "submit" to "button".