### PR TITLE
Make newXMLHttpRequest async, handles errors (#34)

### DIFF
--- a/src/Reflex/Dom/Xhr.hs
+++ b/src/Reflex/Dom/Xhr.hs
@@ -19,6 +19,7 @@ module Reflex.Dom.Xhr
 where
 
 import Control.Concurrent
+import Control.Exception (catch)
 import Control.Lens
 import Control.Monad hiding (forM)
 import Control.Monad.IO.Class
@@ -37,6 +38,7 @@ import Data.Traversable
 import Reflex
 import Reflex.Dom.Class
 import Reflex.Dom.Xhr.Foreign
+import GHCJS.DOM.JSFFI.XMLHttpRequest (XHRError(..))
 import Data.Typeable
 
 data XhrRequest
@@ -100,12 +102,24 @@ instance Default XhrRequestConfig where
 xhrRequest :: String -> String -> XhrRequestConfig -> XhrRequest
 xhrRequest = XhrRequest
 
-newXMLHttpRequest :: (HasWebView m, MonadIO m, HasPostGui t h m) => XhrRequest -> (XhrResponse -> h ()) -> m XMLHttpRequest
+-- | Make a new asyncronous XHR request. This does not block (it forks),
+-- and returns an XHR object immediately (which you can use to abort
+-- the XHR connection), and will pass an exception ('XHRError') to the
+-- continuation if the connection cannot be made (or is aborted).
+newXMLHttpRequest
+    :: (HasWebView m, MonadIO m, HasPostGui t h m)
+    => XhrRequest
+    -- ^ The request to make.
+    -> (Either XHRError XhrResponse -> h ())
+    -- ^ A continuation to be called once a response comes back, or in
+    -- case of error.
+    -> m XMLHttpRequest
+    -- ^ The XHR request, which could for example be aborted.
 newXMLHttpRequest req cb = do
   wv <- askWebView
   postGui <- askPostGui
-  liftIO $ do
-    xhr <- xmlHttpRequestNew wv
+  xhr <- liftIO $ xmlHttpRequestNew wv
+  void $ liftIO $ forkIO $ flip catch (postGui . cb . Left) $ void $ do
     let c = _xhrRequest_config req
         rt = _xhrRequestConfig_responseType c
     xmlHttpRequestOpen
@@ -127,24 +141,42 @@ newXMLHttpRequest req cb = do
                    then liftIO $ xmlHttpRequestGetResponseText xhr
                    else  return Nothing
             r <- liftIO $ xmlHttpRequestGetResponse xhr
-            _ <- liftIO $ postGui $ cb $ XhrResponse { _xhrResponse_status = status
-                                                     , _xhrResponse_statusText = statusTextToText statusText
-                                                     , _xhrResponse_response = r
-                                                     , _xhrResponse_responseText = responseTextToText t
-                                                     }
+            _ <- liftIO $ postGui $ cb $ Right $
+                 XhrResponse { _xhrResponse_status = status
+                             , _xhrResponse_statusText = statusTextToText statusText
+                             , _xhrResponse_response = r
+                             , _xhrResponse_responseText = responseTextToText t
+                             }
             return ()
           else return ()
     _ <- xmlHttpRequestSend xhr (_xhrRequestConfig_sendData c)
-    return xhr
+    return ()
+  return xhr
 
--- | Given Event of requests, issue them when the Event fires.  Returns Event of corresponding responses.
-performRequestAsync :: (MonadWidget t m) => Event t XhrRequest -> m (Event t XhrResponse)
+-- | Given Event of requests, issue them when the Event fires.
+-- Returns Event of corresponding responses.
+--
+-- The request is processed asynchronously, therefore handling does
+-- not block or cause a delay while creating the connection.
+performRequestAsync
+    :: (MonadWidget t m)
+    => Event t XhrRequest -> m (Event t (Either XHRError XhrResponse))
 performRequestAsync req = performEventAsync $ ffor req $ \r cb -> do
   _ <- newXMLHttpRequest r $ liftIO . cb
   return ()
 
--- | Issues a collection of requests when the supplied Event fires.  When ALL requests from a given firing complete, the results are collected and returned via the return Event.
-performRequestsAsync :: (Traversable f, MonadWidget t m) => Event t (f XhrRequest) -> m (Event t (f XhrResponse))
+-- | Issues a collection of requests when the supplied Event fires.
+-- When ALL requests from a given firing complete, the results are
+-- collected and returned via the return Event.
+--
+-- The requests are processed asynchronously, therefore handling does
+-- not block or cause a delay while creating the connection.
+--
+-- Order of request execution and completion is not guaranteed, but
+-- order of creation and the collection result is preserved.
+performRequestsAsync
+    :: (Traversable f, MonadWidget t m)
+    => Event t (f XhrRequest) -> m (Event t (f (Either XHRError XhrResponse)))
 performRequestsAsync req = performEventAsync $ ffor req $ \rs cb -> do
   resps <- forM rs $ \r -> do
     resp <- liftIO newEmptyMVar
@@ -157,11 +189,16 @@ performRequestsAsync req = performEventAsync $ ffor req $ \rs cb -> do
 getAndDecode :: (FromJSON a, MonadWidget t m) => Event t String -> m (Event t (Maybe a))
 getAndDecode url = do
   r <- performRequestAsync $ fmap (\x -> XhrRequest "GET" x def) url
-  return $ fmap decodeXhrResponse r
+  return $
+      fmap (\r ->
+                case r of
+                  Left{} -> Nothing
+                  Right xhr -> decodeXhrResponse xhr)
+           r
 
 -- | Create a "POST" request from an URL and thing with a JSON representation
 postJson :: (ToJSON a) => String -> a -> XhrRequest
-postJson url a = 
+postJson url a =
   XhrRequest "POST" url $ def { _xhrRequestConfig_headers = headerUrlEnc
                               , _xhrRequestConfig_sendData = Just body
                               }
@@ -179,4 +216,3 @@ decodeText = decode . BL.fromStrict . encodeUtf8
 -- | Convenience function to decode JSON-encoded responses.
 decodeXhrResponse :: FromJSON a => XhrResponse -> Maybe a
 decodeXhrResponse = join . fmap decodeText . _xhrResponse_responseText
-


### PR DESCRIPTION
The `newXMLHttpRequest` function presented two issues:

1. Creating an XHR connection in at least one browser (Chrome) blocks
while creating the connection, despite the result coming back
asynchonrously. This creates a certain lag when calling the function,
and thus also causes event handlers to block which delays subsequent
event handlers from running. A simple example is an event containing a
request; there are two handlers for this event (1) a spinner, (2) one
that makes a connection. The one that makes a connection will stop the
spinner from activating. If there is sufficient network delay, the
spinner won't appear for some 300ms to some seconds, defeating the
purpose of a spinner in the first place.

2. Handling an error. Related to the first, creating the XHR connection
blocks but can then throw an XHRError exception, which was not handled
anywhere in the code. Connection timeout is a common issue that
we'd like to handle in the UI (think GMail or Slack displaying a
"disconnected; reconnecting in n seconds..." kind of message), so I've
put the exception in the event's output so that a user-friendly UI
message can be displayed.

I've added some documentation for related functions.